### PR TITLE
Feature/zeus 2141/update attributes api

### DIFF
--- a/reference/Upload-API.yaml
+++ b/reference/Upload-API.yaml
@@ -324,7 +324,7 @@ paths:
                             alias:
                               type: string
                               minLength: 1
-                              description: 'CloudMatrix attribute report value, this should be used as an alias for 3rd party attribute value '
+                              description: CloudMatrix attribute report value, this should be used as an alias for 3rd party attribute value
                             value:
                               type: string
                               minLength: 1


### PR DESCRIPTION
- Added OAS for update attributes API
- Spec includes definition for 200 and 400 responses
- Spec does not include geo-restriction rule update in request as per current requirement