### PR TITLE
feat(removal-of-alias-use-of-report-value): ZEUS-2961

### DIFF
--- a/docs/Guides/Get-Entry-Entitlemnt.md
+++ b/docs/Guides/Get-Entry-Entitlemnt.md
@@ -4,7 +4,7 @@ stoplight-id: 92mz02po829y4
 
 # Get Entry Entitlement
 
-Entry entirlement API is used to get the list of entry entitlement for a given entry. The entitlement to entry is assigned to by the admin and is used to validate if user has valid entitlement to watch the media. 
+Entry entitlement API is used to get the list of entry entitlement for a given entry. The entitlement to entry is assigned to by the admin and is used to validate if user has valid entitlement to watch the media. 
 
 The high level flow diagram:
 

--- a/docs/Guides/XML-enrichment-upload.md
+++ b/docs/Guides/XML-enrichment-upload.md
@@ -51,7 +51,7 @@ There are two attribute ids we ask you to use:
 <!-- theme: warning -->
 > #### The Importance of the filename value in the XML
 >
-> The filename value in the XML must match the title of the video file for us to associated the two files.  If they do not match the video upload will fail.
+> The filename value in the XML must match the title of the video file for us to associate the two files.  If they do not match the video upload will fail.
 
 ## Upload logs
 After each upload attempt the service posts a text file to the `/result` folder in the clients S3 bucket.

--- a/reference/Upload-API.yaml
+++ b/reference/Upload-API.yaml
@@ -206,11 +206,11 @@ paths:
                       id:
                         type: string
                         minLength: 1
-                        description: CloudMatrix attribute id
+                        description: CloudMatrix attribute id (customer attribute conifguration identifier)
                       value:
                         type: string
                         minLength: 1
-                        description: CloudMatrix attribute value
+                        description: CloudMatrix attribute value (valid report option for a dropdown type)
                       items:
                         type: array
                         uniqueItems: true
@@ -223,11 +223,7 @@ paths:
                             value:
                               type: string
                               minLength: 1
-                              description: CloudMatrix attribute value
-                            alias:
-                              type: string
-                              minLength: 1
-                              description: 'CloudMatrix attribute report value, this should be used as an alias for 3rd party attribute value'
+                              description: CloudMatrix attribute value (valid report option for a dropdown type)
                           required:
                             - value
                     required:
@@ -315,10 +311,8 @@ paths:
                         - value: entitlement2
                     - id: a61de76c-e367-4c63-93e0-2d6fd6e256cf
                       items:
-                        - alias: '1234'
-                          value: Team A
-                        - alias: '6789'
-                          value: Team B
+                        - value: Team A Report Value
+                        - value: Team B Report Value
                   publication:
                     publish: true
                     from: '2022-03-06T22:51:25Z'
@@ -645,10 +639,8 @@ paths:
                     - id: e078d72a-aad4-4b68-9227-e0bde0b35c6d
                       value: Some Title
                       items:
-                        - alias: '1234'
-                          value: Team A
-                        - alias: '6789'
-                          value: Team B
+                        - value: Team A Report Value
+                        - value: Team B Report Value
                     - id: 57e816fb-03b7-4706-a99f-5c6ef8d18ada
                       value: Some Description
                     - id: 57e816fb-03b7-4706-a99f-5c6ef8d18adb
@@ -659,10 +651,8 @@ paths:
                         - value: entitlement2
                     - id: a61de76c-e367-4c63-93e0-2d6fd6e256cf
                       items:
-                        - alias: '1234'
-                          value: Team A
-                        - alias: '6789'
-                          value: Team B
+                        - value: Team A Report Value
+                        - value: Team B Report Value
                   publication:
                     publish: true
                     from: '2022-03-06T22:51:25Z'
@@ -699,7 +689,7 @@ paths:
                       value:
                         type: string
                         minLength: 1
-                        description: CloudMatrix attribute value
+                        description: CloudMatrix attribute value (valid report option for a dropdown type)
                       items:
                         type: array
                         uniqueItems: true
@@ -709,14 +699,10 @@ paths:
                           type: object
                           additionalProperties: false
                           properties:
-                            alias:
-                              type: string
-                              minLength: 1
-                              description: 'CloudMatrix attribute report value, this should be used as an alias for 3rd party attribute value '
                             value:
                               type: string
                               minLength: 1
-                              description: CloudMatrix attribute value
+                              description: CloudMatrix attribute value (valid report option for a dropdown type)
                           required:
                             - value
                     required:
@@ -804,10 +790,8 @@ paths:
                         - value: entitlement2
                     - id: a61de76c-e367-4c63-93e0-2d6fd6e256cf
                       items:
-                        - alias: '1234'
-                          value: Team A
-                        - alias: '6789'
-                          value: Team B
+                        - value: Team A Report Value
+                        - value: Team B Report Value
                   publication:
                     publish: true
                     from: '2022-03-06T22:51:25Z'

--- a/reference/Upload-API.yaml
+++ b/reference/Upload-API.yaml
@@ -206,7 +206,7 @@ paths:
                       id:
                         type: string
                         minLength: 1
-                        description: CloudMatrix attribute id (customer attribute conifguration identifier)
+                        description: CloudMatrix attribute id (customer attribute configuration identifier)
                       value:
                         type: string
                         minLength: 1


### PR DESCRIPTION
Removal of alias as a payload entity now for an attribute and example changes to try indicate that the report value for a dropdown type is what is required. Some grammar corrections as well.